### PR TITLE
Add and implement EntityInterface

### DIFF
--- a/src/application/board/modules/manage/board/board.php
+++ b/src/application/board/modules/manage/board/board.php
@@ -43,7 +43,7 @@ class manage_board_board_board extends kxCmd
 
   private function onRegen()
   {
-    $board = Edaha\Entities\Board::loadBoardFromDbByName($this->request['board'], $this->db);
+    $board = Edaha\Entities\Board::loadFromDbByName($this->request['board'], $this->db);
     if (is_null($board)) {
       $this->errorMessage = sprintf(_("Couldn't find board /%s/."), $this->request['board']);
       return false;

--- a/src/application/board/modules/manage/contentmoderation/posts.php
+++ b/src/application/board/modules/manage/contentmoderation/posts.php
@@ -40,7 +40,7 @@ class manage_board_contentmoderation_posts extends kxCmd
       foreach ($this->request['posts'] as $post) {
         $board_id = (int) explode('|', $post)[0];
         $post_id = (int) explode('|', $post)[1];
-        $post = Edaha\Entities\Post::loadPostFromAssoc(
+        $post = Edaha\Entities\Post::loadFromAssoc(
           [
             'board_id' => $board_id, 
             'post_id' => $post_id

--- a/src/application/board/modules/public/base/baseboard.php
+++ b/src/application/board/modules/public/base/baseboard.php
@@ -71,7 +71,7 @@ class public_board_base_baseboard extends kxCmd
    */
   public function exec(kxEnv $environment)
   {
-    $this->board = Edaha\Entities\Board::loadBoardFromDbByName($this->request['board'], $this->db);
+    $this->board = Edaha\Entities\Board::loadFromDbByName($this->request['board'], $this->db);
 
     $this->environment->set('kx:classes:board:id', $this->board);
 

--- a/src/application/lib/Edaha/Entities/EntityInterface.php
+++ b/src/application/lib/Edaha/Entities/EntityInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Edaha\Entities;
+
+interface EntityInterface {
+    public static function loadFromDb(array $identifiers, object &$db);
+    public static function loadFromAssoc(array $assoc);
+}

--- a/src/application/lib/Edaha/Entities/Post.php
+++ b/src/application/lib/Edaha/Entities/Post.php
@@ -1,7 +1,7 @@
 <?php
 namespace Edaha\Entities;
 
-class Post
+class Post implements EntityInterface
 {
     public object $db;
 
@@ -110,18 +110,20 @@ class Post
         }
     }
 
-    public static function loadPostFromDb(int $board_id, int $post_id, object &$db)
+    public static function loadFromDb(array $identifiers, object &$db)
     {
-        $post           = new Post($board_id, $post_id, $db);
-        if (!$post->validatePost()) return false;
+        if (!array_key_exists('board_id', $identifiers) || !array_key_exists('post_id', $identifiers)) return null;
+
+        $post           = new Post($identifiers['board_id'], $identifiers['post_id'], $db);
+        if (!$post->validatePost()) return null;
 
         $post->loadPostFields();
         return $post;
     }
 
-    public static function loadPostFromAssoc(array $assoc, ?object &$db = null)
+    public static function loadFromAssoc(array $assoc)
     {
-        $post = new Post($assoc['board_id'], $assoc['post_id'], $db);
+        $post = new Post($assoc['board_id'], $assoc['post_id']);
 
         foreach ($assoc as $key => $value) {
             if (!is_null($value)) $post->$key = $value;
@@ -141,7 +143,7 @@ class Post
             ->execute();
         
         while ($row = $results->fetchAssoc()) {
-            $recent_posts[] = Post::loadPostFromAssoc($row);
+            $recent_posts[] = Post::loadFromAssoc($row);
         }
 
         return $recent_posts;

--- a/src/application/lib/Edaha/Entities/Thread.php
+++ b/src/application/lib/Edaha/Entities/Thread.php
@@ -11,18 +11,20 @@ class Thread extends Post
             return $this->validateThread();
         }
     }
-
-    public static function loadThread(int $board_id, int $post_id, object &$db)
+    public static function loadFromDb(array $identifiers, object &$db)
     {
-        $thread = new Thread($board_id, $post_id, $db);
+        if (!array_key_exists('board_id', $identifiers) || !array_key_exists('post_id', $identifiers)) return null;
 
+        $thread           = new Thread($identifiers['board_id'], $identifiers['post_id'], $db);
         if (!$thread->validatePost()) return false;
+        
         $thread->loadPostFields();
         if (!$thread->validateThread()) return false;
+        
         return $thread;
     }
 
-    public static function loadThreadFromAssoc(array $assoc, ?object &$db = null)
+    public static function loadFromAssoc(array $assoc)
     {
         $thread = new Thread($assoc['board_id'], $assoc['post_id'], $db);
 
@@ -53,7 +55,7 @@ class Thread extends Post
             ->execute();
         
         while ($row = $results->fetchAssoc()) {
-            $this->replies[] = Post::loadPostFromAssoc($row);
+            $this->replies[] = Post::loadFromAssoc($row);
         }
     }
 
@@ -81,7 +83,7 @@ class Thread extends Post
             ->execute();
         
         while ($row = $results->fetchAssoc()) {
-            $this->replies[] = Post::loadPostFromAssoc($row);
+            $this->replies[] = Post::loadFromAssoc($row);
         }
 
         if ($first_or_last == 'last')  $this->replies = array_reverse($this->replies);

--- a/src/psr4test.php
+++ b/src/psr4test.php
@@ -3,7 +3,7 @@ DEFINE('IN_MANAGE', false);
 include "init.php";
 
 $db = kxDb::getInstance();
-$post = ("Edaha\\" . "Entities\\" . "Post")::loadPostFromDb(1, 120, $db);
+$post = ("Edaha\\" . "Entities\\" . "Post")::loadFromDb(['board_id' => 1, 'post_id' => 120], $db);
 
 echo('<pre>');
 print_r($post);
@@ -11,14 +11,14 @@ print_r($post);
 print((int) $post->is_deleted);
 echo('</pre>');
 
-$thread = Edaha\Entities\Thread::loadThread(8, 168, $db);
+$thread = Edaha\Entities\Thread::loadFromDb(['board_id' => 8, 'post_id' => 168], $db);
 $thread->getAllReplies();
 
 echo('<pre>');
 print_r($thread);
 echo('</pre>');
 
-$thread = Edaha\Entities\Thread::loadThread(69, 69, $db);
+$thread = Edaha\Entities\Thread::loadFromDb(['board_id' => 69, 'post_id' => 69], $db);
 if ($thread) { 
     echo 'true'; 
 } else 
@@ -40,7 +40,7 @@ print_r($posts);
 echo('</pre>');
 
 
-$post = Edaha\Entities\Post::loadPostFromDb(15, 212, $db);
+$post = Edaha\Entities\Post::loadFromDb(['board_id' => 15, 'post_id' => 212], $db);
 echo('<pre>');
 print_r($post);
 echo('</pre>');
@@ -51,12 +51,12 @@ print_r($post);
 echo('</pre>');
 
 $post = null;
-$post = Edaha\Entities\Post::loadPostFromDb(15, 188, $db);
+$post = Edaha\Entities\Post::loadFromDb(['board_id' => 15, 'post_id' => 188], $db);
 echo('<pre>');
 print_r($post);
 echo('</pre>');
 
-$board = Edaha\Entities\Board::loadBoardFromDb(15, $db);
+$board = Edaha\Entities\Board::loadFromDb(['board_id' => 15], $db);
 echo('<pre>');
 print_r($board);
 echo('</pre>');
@@ -72,7 +72,7 @@ print_r($board);
 echo('</pre>');
 
 
-$thread = Edaha\Entities\Thread::loadThread(8, 168, $db);
+$thread = Edaha\Entities\Thread::loadFromDb(['board_id' => 8, 'post_id' => 168], $db);
 $thread->getReplies();
 
 echo('<pre>');
@@ -93,7 +93,13 @@ echo('</pre>');
 
 
 
-$board = Edaha\Entities\Board::loadBoardFromDbByName('edakiri', $db);
+$board = Edaha\Entities\Board::loadFromDbByName('edakiri', $db);
+echo('<pre>');
+print_r($board);
+echo('</pre>');
+
+echo 'here';
+$board = Edaha\Entities\Board::loadFromDb(['board_id' => 15], $db);
 echo('<pre>');
 print_r($board);
 echo('</pre>');


### PR DESCRIPTION
This creates a simple interface `EntityInterface` and then implements it for the `Board`, `Post`, and `Thread` classes. This is intended to define the standard ways to create a new object of each class and pre-populate its properties  with data from a db (kxDb instance) or an associative array. This will be used on future Entities as well.